### PR TITLE
v2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.1', '8.2', '8.3', '8.4' ]
-        orchestra-versions: [ '9.0', '10.0' ]
+        php-versions: [ '8.2', '8.3', '8.4', '8.5' ]
+        orchestra-versions: [ '9.0', '10.0', '11.0' ]
         exclude:
-          - php-versions: 8.1
+          # Laravel 13 (Testbench 11) requires PHP >= 8.3
+          - php-versions: 8.2
+            orchestra-versions: 11.0
+          # Laravel 11 (Testbench 9) does not support PHP 8.5
+          - php-versions: 8.5
             orchestra-versions: 9.0
-          - php-versions: 8.1
+          # Laravel 12 (Testbench 10) does not support PHP 8.5
+          - php-versions: 8.5
             orchestra-versions: 10.0
     steps:
       - name: Checkout
@@ -39,6 +44,15 @@ jobs:
 
       - name: Remove QA dependencies
         run: composer remove laravel/pint phpstan/phpstan --dev --no-update
+
+      # Laravel 11 (Testbench 9) is EOL and carries unpatched security advisories,
+      # so composer blocks its install by default. Dt0 still supports it, so allow
+      # it in CI only (never touches the committed composer.json).
+      - name: Allow advisory-flagged dependencies (Laravel 11 is EOL)
+        run: composer config --global policy.advisories.block false
+
+      - name: Pin Testbench version
+        run: composer require --dev "orchestra/testbench:^${{ matrix.orchestra-versions }}" --no-update
 
       - name: Install Composer dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
           extensions: mbstring, dom, fileinfo, gmp, bcmath
           coverage: xdebug
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .phpstan
 composer.lock
 /cov
+.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- Benchmark harness (`benchmark/compare-spatie.php`) no longer throws `DivisionByZeroError` on fast machines: cached serialization can dip below the previous 0.1 µs display precision, which rounded to `0` and broke the speedup ratio. Timings now feed the ratio at full precision, and sub-µs values render with more decimals. Published benchmark tables refreshed on PHP 8.5.
+
+## [2.0.0] - 2026-07-15
+
+### Breaking Changes
+
+#### Minimum PHP 8.2
+
+Dropped PHP 8.1 support — the minimum is now PHP 8.2. PHP 8.1 was already untested in practice: the previous CI matrix excluded it from every Laravel/Testbench combination, since Laravel 11+ requires PHP 8.2+. Projects still on PHP 8.1 can continue using the 1.0.x line.
+
+### Added
+
+#### PHP 8.5 support
+
+Full support for PHP 8.5, including its stricter runtime checks.
+
+#### Laravel 13 support
+
+Support for Laravel 13 (`illuminate/* ^13.0`, `orchestra/testbench ^11.0`) alongside Laravel 11 and 12. The standalone `Validator` and the `trans()` / `__()` / `trans_choice()` helpers are verified against Laravel 13 in both standalone mode (self-contained translator) and inside a Laravel app (defers to the framework's own helpers). The CI matrix now covers PHP 8.2–8.5 across Laravel 11/12/13, and QA/coverage runs on PHP 8.5.
+
+#### Documentation
+
+`docs/extending.md` now notes that custom attribute implementations must declare their own `#[Attribute(...)]` on the concrete class, since PHP does not inherit the marker from a parent or abstract class.
+
+### Fixed
+
+#### PHP 8.5 compatibility
+
+- The `#[Attribute]` marker was removed from the abstract attribute base classes (`CastAbstract`, `CastsAbstract`, `RuleAbstract`, `RulesAbstract`, `ValidateAbstract`, `WithAbstract`): PHP 8.5 makes `#[Attribute]` on an abstract class a fatal error. This is internal only — the marker is required (and still declared) on the concrete attributes, and PHP never inherited it by subclasses, so custom attribute implementations are unaffected.
+- `ReflectionProperty::getDefaultValue()` is now guarded behind `hasDefaultValue()`, avoiding a PHP 8.5 deprecation for properties declared without a default.
+
+#### Timezone now applied to immutable dates from array input
+
+Date casters (`DateTimeCaster`, `DateTimeImmutable`) now correctly apply the timezone when hydrating from an array containing a `timezone` entry. Previously the result of `setTimezone()` was discarded, so the timezone was silently ignored for immutable date instances (surfaced as a warning under PHP 8.5).
+
 ## [1.0.1] - 2026-02-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Immutable PHP DTOs with bidirectional casting. No framework required. [~8x faster](#benchmarks) than the alternative.**
 
-`Dt0` (_DeeTO_) is a PHP 8.1+ [Data Transfer Object](https://en.wikipedia.org/wiki/Data_transfer_object) implementation that uses native `readonly` properties for true immutability. One `#[Cast]` attribute handles input transformation, output formatting, defaults, and property renaming. Compiled once per class, fast always.
+`Dt0` (_DeeTO_) is a PHP 8.2+ [Data Transfer Object](https://en.wikipedia.org/wiki/Data_transfer_object) implementation that uses native `readonly` properties for true immutability. One `#[Cast]` attribute handles input transformation, output formatting, defaults, and property renaming. Compiled once per class, fast always.
 
 ## Quick Start
 
@@ -310,23 +310,23 @@ Reflection and attribute metadata compiled **once per class, per process**. Subs
 
 <a id="benchmarks"></a>
 
-#### Dt0 vs spatie/laravel-data (PHP 8.4, 10,000 iterations)
+#### Dt0 vs spatie/laravel-data (PHP 8.5, 10,000 iterations)
 
 | Operation | Dt0 | spatie/laravel-data | Speedup |
 |-----------|-----|---------------------|---------|
-| Simple DTO (8 props, 5 casts) | 141.6 µs | 1,158 µs | **~8.2x faster** |
-| Complex DTO (nested + arrays) | 741.9 µs | 3,628 µs | **~4.9x faster** |
-| Round-trip (json->dto->json) | 248.4 µs | 2,004 µs | **~8.1x faster** |
+| Simple DTO (8 props, 5 casts) | 2.6 µs | 17.1 µs | **~6.5x faster** |
+| Complex DTO (nested + arrays) | 11.6 µs | 67.7 µs | **~5.8x faster** |
+| Round-trip (json->dto->json) | 5.0 µs | 31.8 µs | **~6.4x faster** |
 
 **Repeated serialization (same instance):**
 
 | Operation | Dt0 | spatie/laravel-data | Speedup |
 |-----------|-----|---------------------|---------|
-| toArray() (simple) | 3.6 µs | 679.4 µs | **~188.7x faster** |
-| toArray() (nested) | 3.6 µs | 2,056 µs | **~571.1x faster** |
-| toJson() | 2.8 µs | 681.8 µs | **~243.5x faster** |
+| toArray() (simple) | 0.085 µs | 9.1 µs | **~107x faster** |
+| toArray() (nested) | 0.103 µs | 30.1 µs | **~292x faster** |
+| toJson() | 0.034 µs | 9.3 µs | **~277x faster** |
 
-Output caching delivers 188-571x improvements when serializing the same instance multiple times (API + logging, event sourcing, queue + monitoring, caching layers).
+Output caching delivers ~107-292x improvements when serializing the same instance multiple times (API + logging, event sourcing, queue + monitoring, caching layers). Absolute timings are hardware-dependent; the speedup ratios are what matter.
 
 ```shell
 php benchmark/compare-spatie.php
@@ -348,7 +348,7 @@ All exceptions extend [`ContextException`](https://github.com/fab2s/ContextExcep
 
 ## Requirements
 
-- PHP 8.1, 8.2, 8.3, or 8.4
+- PHP 8.2, 8.3, 8.4, or 8.5
 
 ## Dependencies
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -24,35 +24,37 @@ The benchmark uses realistic DTOs with:
 | toArray() / toJson() | Serialization with output transformers |
 | Round-trip | JSON → DTO → JSON |
 
-## Results (PHP 8.4, 10,000 iterations)
+## Results (PHP 8.5, 10,000 iterations)
+
+Absolute timings are hardware-dependent; the speedup ratios are the meaningful figure.
 
 ### Hydration & Round-trip
 
 | Operation | Dt0 | spatie/laravel-data | Speedup |
 |-----------|-----|---------------------|--------|
-| Simple DTO (8 props, 5 casts) | 136.9 µs | 1,117 µs | **~8.2x faster** |
-| Complex DTO (nested + arrays) | 711.5 µs | 3,494 µs | **~4.9x faster** |
-| Round-trip (json→dto→json) | 246.8 µs | 1,960 µs | **~7.9x faster** |
+| Simple DTO (8 props, 5 casts) | 2.6 µs | 17.1 µs | **~6.5x faster** |
+| Complex DTO (nested + arrays) | 11.6 µs | 67.7 µs | **~5.8x faster** |
+| Round-trip (json→dto→json) | 5.0 µs | 31.8 µs | **~6.4x faster** |
 
 ### Repeated Serialization (same instance)
 
 | Operation | Dt0 | spatie/laravel-data | Speedup |
 |-----------|-----|---------------------|--------|
-| toArray() (simple) | 3.5 µs | 625.8 µs | **~178.8x faster** |
-| toArray() (nested) | 3.6 µs | 1,978 µs | **~549.3x faster** |
-| toJson() | 2.4 µs | 627.5 µs | **~261.5x faster** |
+| toArray() (simple) | 0.085 µs | 9.1 µs | **~107x faster** |
+| toArray() (nested) | 0.103 µs | 30.1 µs | **~292x faster** |
+| toJson() | 0.034 µs | 9.3 µs | **~277x faster** |
 
 ## Understanding the Results
 
-**Hydration (~5-8x faster)**: Dt0's compile-once architecture pre-computes property mappings, casters, and defaults. This is the baseline performance gain you get on every DTO creation.
+**Hydration (~6x faster)**: Dt0's compile-once architecture pre-computes property mappings, casters, and defaults. This is the baseline performance gain you get on every DTO creation.
 
-**Repeated serialization (~178-549x faster)**: When serializing the same instance multiple times, Dt0 caches the output structure on first call. Subsequent calls reuse the cache. This applies to scenarios like:
+**Repeated serialization (~107-292x faster)**: When serializing the same instance multiple times, Dt0 caches the output structure on first call. Subsequent calls reuse the cache. This applies to scenarios like:
 - Logging the same DTO at multiple points
 - Serializing for both response and event dispatch
 - Caching serialized output
 
-The nested DTO shows the largest speedup (~549x) because spatie/laravel-data must traverse and transform the entire object graph on every call, while Dt0 simply returns the cached result.
+The nested DTO shows the largest speedup (~292x) because spatie/laravel-data must traverse and transform the entire object graph on every call, while Dt0 simply returns the cached result.
 
-**Single-use serialization (~10x faster)**: For one-shot serialization (create DTO, serialize once, discard), expect performance similar to hydration benchmarks.
+**Single-use serialization (~6x faster)**: For one-shot serialization (create DTO, serialize once, discard), expect performance similar to hydration benchmarks.
 
 The honest baseline is **~5-10x faster** across typical operations, with massive gains for repeated serialization scenarios.

--- a/benchmark/compare-spatie.php
+++ b/benchmark/compare-spatie.php
@@ -286,7 +286,7 @@ class BenchmarkRunner extends TestCase
     {
         $dt0    = $this->benchmark($dt0Fn, $iterations);
         $spatie = $this->benchmark($spatieFn, $iterations);
-        $ratio  = round($spatie['per_op_us'] / $dt0['per_op_us'], 1);
+        $ratio  = $dt0['per_op_us'] > 0 ? round($spatie['per_op_us'] / $dt0['per_op_us'], 1) : INF;
 
         return [
             'name'   => $name,
@@ -315,8 +315,11 @@ class BenchmarkRunner extends TestCase
         $timeMs = ($end - $start) / 1_000_000;
         $perOp  = $timeMs         / $iterations;
 
+        // Keep the raw per-op time (µs). Sub-µs operations (e.g. cached
+        // serialization) must not be rounded here or the speedup ratio would
+        // divide by zero. Rounding happens only at display time.
         return [
-            'per_op_us' => round($perOp * 1000, 1),
+            'per_op_us' => $perOp * 1000,
         ];
     }
 
@@ -326,12 +329,24 @@ class BenchmarkRunner extends TestCase
         echo "|-----------|-----|---------------------|--------|\n";
 
         foreach ($results as $row) {
-            $dt0Str    = $row['dt0']    >= 1000 ? number_format($row['dt0']) . ' µs' : $row['dt0'] . ' µs';
-            $spatieStr = $row['spatie'] >= 1000 ? number_format($row['spatie']) . ' µs' : $row['spatie'] . ' µs';
-            $speedup   = "**~{$row['ratio']}x faster**";
+            $dt0Str    = $this->formatUs($row['dt0']);
+            $spatieStr = $this->formatUs($row['spatie']);
+            $speedup   = is_finite($row['ratio']) ? "**~{$row['ratio']}x faster**" : '**faster**';
 
             echo "| {$row['name']} | {$dt0Str} | {$spatieStr} | {$speedup} |\n";
         }
+    }
+
+    private function formatUs(float $us): string
+    {
+        if ($us >= 1000) {
+            return number_format($us) . ' µs';
+        }
+
+        // More decimals as the value gets smaller, so sub-µs timings stay visible.
+        $decimals = $us >= 100 ? 1 : ($us >= 1 ? 2 : 3);
+
+        return round($us, $decimals) . ' µs';
     }
 
     private function formatBytes(int $bytes): string

--- a/composer.json
+++ b/composer.json
@@ -28,17 +28,17 @@
         "MIT"
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-zlib": "*",
         "fab2s/context-exception": "^2.0|^3.0",
         "fab2s/enumerate": "^0.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0|^11.0",
+        "phpunit/phpunit": "^11.0|^12.0",
         "laravel/pint": "^1.21.2",
-        "orchestra/testbench": "^9.0|^10.0",
-        "illuminate/translation": "^11.0|^12.0",
-        "illuminate/validation": "^11.0|^12.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "illuminate/translation": "^11.0|^12.0|^13.0",
+        "illuminate/validation": "^11.0|^12.0|^13.0",
         "nesbot/carbon": "^2.62|^3.0",
         "fab2s/math": "^2.0",
         "spatie/laravel-data": "^4.19",

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -19,6 +19,23 @@ Dt0's attributes and validation are extensible. Implement the appropriate interf
 | Property rule | [`RuleInterface`](../src/Attribute/RuleInterface.php) | [`RuleAbstract`](../src/Attribute/RuleAbstract.php) |
 | Output control | [`WithInterface`](../src/Attribute/WithInterface.php) | [`WithAbstract`](../src/Attribute/WithAbstract.php) |
 
+> **Declare `#[Attribute]` on your concrete class.** PHP never inherits the `#[Attribute]` marker
+> from a parent or abstract class, so when you extend one of the abstract classes above you must add
+> `#[Attribute(...)]` with the appropriate target to your own concrete class — otherwise PHP throws
+> *"Attempting to use non-attribute class as attribute"*. Dt0 walks the class tree to resolve
+> inherited attributes, but always instantiates the concrete attribute you declared:
+>
+> ```php
+> use Attribute;
+> use fab2s\Dt0\Attribute\CastAbstract;
+>
+> #[Attribute(Attribute::TARGET_PROPERTY)] // required on the concrete class
+> class MyCast extends CastAbstract
+> {
+>     // ...
+> }
+> ```
+
 ## Compiled Property Metadata
 
 Access the compiled metadata for any Dt0 class:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,8 +11,6 @@ parameters:
 
     ignoreErrors:
         -
-            identifier: attribute.abstract
-        -
             identifier: property.uninitializedReadonly
         -
             identifier: new.static

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage/>
   <testsuites>
     <testsuite name="CI">

--- a/src/Attribute/CastAbstract.php
+++ b/src/Attribute/CastAbstract.php
@@ -11,13 +11,11 @@ declare(strict_types=1);
 
 namespace fab2s\Dt0\Attribute;
 
-use Attribute;
 use fab2s\Dt0\Caster\CasterInterface;
 use fab2s\Dt0\Concern\HasCasterInstance;
 use fab2s\Dt0\Concern\HasDeclaringFqn;
 use fab2s\Dt0\Concern\HasPropName;
 
-#[Attribute(Attribute::TARGET_PROPERTY)]
 abstract class CastAbstract implements CastInterface
 {
     use HasCasterInstance;

--- a/src/Attribute/CastsAbstract.php
+++ b/src/Attribute/CastsAbstract.php
@@ -11,10 +11,8 @@ declare(strict_types=1);
 
 namespace fab2s\Dt0\Attribute;
 
-use Attribute;
 use fab2s\Dt0\Concern\HasDeclaringFqn;
 
-#[Attribute(Attribute::TARGET_CLASS)]
 abstract class CastsAbstract implements CastsInterface
 {
     use HasDeclaringFqn;

--- a/src/Attribute/RuleAbstract.php
+++ b/src/Attribute/RuleAbstract.php
@@ -11,11 +11,9 @@ declare(strict_types=1);
 
 namespace fab2s\Dt0\Attribute;
 
-use Attribute;
 use fab2s\Dt0\Concern\HasDeclaringFqn;
 use fab2s\Dt0\Concern\HasPropName;
 
-#[Attribute(Attribute::TARGET_PROPERTY)]
 abstract class RuleAbstract implements RuleInterface
 {
     use HasDeclaringFqn;

--- a/src/Attribute/RulesAbstract.php
+++ b/src/Attribute/RulesAbstract.php
@@ -11,10 +11,8 @@ declare(strict_types=1);
 
 namespace fab2s\Dt0\Attribute;
 
-use Attribute;
 use fab2s\Dt0\Concern\HasDeclaringFqn;
 
-#[Attribute(Attribute::TARGET_CLASS)]
 abstract class RulesAbstract implements RulesInterface
 {
     use HasDeclaringFqn;

--- a/src/Attribute/ValidateAbstract.php
+++ b/src/Attribute/ValidateAbstract.php
@@ -11,11 +11,9 @@ declare(strict_types=1);
 
 namespace fab2s\Dt0\Attribute;
 
-use Attribute;
 use fab2s\Dt0\Concern\HasDeclaringFqn;
 use fab2s\Dt0\Validator\ValidatorInterface;
 
-#[Attribute(Attribute::TARGET_CLASS)]
 abstract class ValidateAbstract implements ValidateInterface
 {
     use HasDeclaringFqn;

--- a/src/Attribute/WithAbstract.php
+++ b/src/Attribute/WithAbstract.php
@@ -11,10 +11,8 @@ declare(strict_types=1);
 
 namespace fab2s\Dt0\Attribute;
 
-use Attribute;
 use fab2s\Dt0\Concern\HasDeclaringFqn;
 
-#[Attribute(Attribute::TARGET_CLASS)]
 abstract class WithAbstract implements WithInterface
 {
     use HasDeclaringFqn;

--- a/src/Caster/DateTimeTrait.php
+++ b/src/Caster/DateTimeTrait.php
@@ -55,7 +55,7 @@ trait DateTimeTrait
         if (! empty($date['date'])) {
             $result = new $this->dateTimeClass((string) $date['date']); // @phpstan-ignore cast.string
             if (! empty($date['timezone'])) {
-                $result->setTimeZone($date['timezone'] instanceof DateTimeZone ? $date['timezone'] : new DateTimeZone((string) $date['timezone'])); // @phpstan-ignore cast.string
+                $result = $result->setTimeZone($date['timezone'] instanceof DateTimeZone ? $date['timezone'] : new DateTimeZone((string) $date['timezone'])); // @phpstan-ignore cast.string
             }
         }
 

--- a/src/Dt0.php
+++ b/src/Dt0.php
@@ -92,7 +92,7 @@ abstract class Dt0 implements ArrayAccess, IteratorAggregate, JsonSerializable, 
         foreach ($properties->earlyInits() as $name => $property) {
             if ($property->needEarlyCast) {
                 if (static::initializeValue($properties, $property, $args, $value)) {
-                    $args[$name] = $property->cast($value, $args);
+                    $args[$name] = $property->cast($value, $args); // @phpstan-ignore argument.type
                 }
 
                 continue;

--- a/src/Property/Properties.php
+++ b/src/Property/Properties.php
@@ -97,13 +97,13 @@ class Properties
             $rule = Property::resolveAttribute($reflectionProperty, RuleInterface::class)
                 ?: (
                     $rules?->hasRule($name)
-                    ? $rules->getRule($name) // @phpstan-ignore method.nonObject
-                        ->setDeclaringFqn($reflection->getName())
+                    ? $rules->getRule($name)
+                        ->setDeclaringFqn($reflection->getName()) // @phpstan-ignore method.nonObject
                         ->setPropName($name)
                     : (
                         $validatorRules?->hasRule($name)
-                        ? $validatorRules->getRule($name) // @phpstan-ignore method.nonObject
-                            ->setDeclaringFqn($reflection->getName())
+                        ? $validatorRules->getRule($name)
+                            ->setDeclaringFqn($reflection->getName()) // @phpstan-ignore method.nonObject
                             ->setPropName($name)
                         : null
                     )

--- a/src/Type/Types.php
+++ b/src/Type/Types.php
@@ -84,11 +84,13 @@ class Types
 
         assert($this->property instanceof ReflectionProperty);
 
+        $hasDefault = $this->property->hasDefaultValue();
+
         return [
             'isReadOnly'     => $this->property->isReadOnly(),
-            'hasDefault'     => $this->property->hasDefaultValue(),
+            'hasDefault'     => $hasDefault,
             'isDefault'      => $this->property->isDefault(),
-            'default'        => $this->property->getDefaultValue(),
+            'default'        => $hasDefault ? $this->property->getDefaultValue() : null,
             'isNullable'     => $isNullable,
             'isUnion'        => $isUnion,
             'isIntersection' => $isIntersection,

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -41,10 +41,10 @@ if (! function_exists('trans_choice')) {
     /**
      * Translates the given message based on a count.
      *
-     * @param \Countable|int|float|array<array-key, mixed> $number
-     * @param array<string, string>                        $replace
+     * @param Countable|int|float|array<array-key, mixed> $number
+     * @param array<string, string>                       $replace
      */
-    function trans_choice(string $key, \Countable|int|float|array $number, array $replace = [], ?string $locale = null): string
+    function trans_choice(string $key, Countable|int|float|array $number, array $replace = [], ?string $locale = null): string
     {
         /** @var Translator $translator */
         $translator = trans();

--- a/tests/Caster/Base64CasterTest.php
+++ b/tests/Caster/Base64CasterTest.php
@@ -32,7 +32,7 @@ class Base64CasterTest extends TestCase
     public function test_encode_on_output(): void
     {
         $caster = Base64Caster::make();
-        $dt0    = $this->createMock(Dt0::class);
+        $dt0    = $this->createStub(Dt0::class);
 
         // Output context: $data is Dt0
         $result = $caster->cast('hello world', $dt0);
@@ -45,7 +45,7 @@ class Base64CasterTest extends TestCase
         $caster = Base64Caster::make();
 
         $this->assertNull($caster->cast(null, []));
-        $this->assertNull($caster->cast(null, $this->createMock(Dt0::class)));
+        $this->assertNull($caster->cast(null, $this->createStub(Dt0::class)));
     }
 
     public function test_non_string_returns_null(): void
@@ -81,7 +81,7 @@ class Base64CasterTest extends TestCase
         $binary = "\x00\x01\x02\xff\xfe\xfd";
 
         // Encode
-        $encoded = $caster->cast($binary, $this->createMock(Dt0::class));
+        $encoded = $caster->cast($binary, $this->createStub(Dt0::class));
 
         // Decode
         $decoded = $caster->cast($encoded, []);

--- a/tests/Caster/JsonCasterTest.php
+++ b/tests/Caster/JsonCasterTest.php
@@ -74,7 +74,7 @@ class JsonCasterTest extends TestCase
         $caster = JsonCaster::make();
 
         $this->assertNull($caster->cast(null, []));
-        $this->assertNull($caster->cast(null, $this->createMock(Dt0::class)));
+        $this->assertNull($caster->cast(null, $this->createStub(Dt0::class)));
     }
 
     /**
@@ -108,7 +108,7 @@ class JsonCasterTest extends TestCase
     public function test_invalid_value_on_output(): void
     {
         $caster = JsonCaster::make();
-        $dt0    = $this->createMock(Dt0::class);
+        $dt0    = $this->createStub(Dt0::class);
 
         // Non-array/object on output returns null
         $this->assertNull($caster->cast('string', $dt0));


### PR DESCRIPTION
PHP 8.5 & Laravel 13 support:
- PHP 8.5: remove #[Attribute] from abstract classes (8.5 fatal), guard getDefaultValue() with hasDefaultValue(), apply setTimezone() result to immutable dates.
- Laravel 13 support (illuminate/* ^13, orchestra/testbench ^11); CI matrix extended to PHP 8.2-8.5 across Laravel 11/12/13; QA/coverage on 8.5.
- Raise minimum PHP to 8.2 (drop 8.1).
- Fix benchmark harness division-by-zero and refresh benchmarks on PHP 8.5.